### PR TITLE
Support basic array values

### DIFF
--- a/rollup/build.js
+++ b/rollup/build.js
@@ -12,6 +12,7 @@ export default {
         file: './dist/bundle/module.js',
         format: 'es'
     }],
+    external: ['smart-table-json-pointer'],
     plugins: [
         node({
             only: ['re-template-tag']

--- a/src/basic.ts
+++ b/src/basic.ts
@@ -13,7 +13,11 @@ export const basic = <T>(input: BasicSearchInput): SearchFunction<T> => {
     }
     const test = isCaseSensitive === true ? String(value) : String(value).toLowerCase();
     return (array: T[]): T[] => array.filter(item => searchPointers.some(p => {
-        const v = isCaseSensitive === true ? String(p(item)) : String(p(item)).toLowerCase();
-        return v.includes(test);
+        let v = p(item);
+        v = Array.isArray(v) ? v : [v];
+        return v.some(e => {
+            const str = isCaseSensitive === true ? String(e) : String(e).toLowerCase();
+            return str.includes(test);
+        })
     }));
 };

--- a/src/basic.ts
+++ b/src/basic.ts
@@ -12,12 +12,15 @@ export const basic = <T>(input: BasicSearchInput): SearchFunction<T> => {
         return (array: T[]): T[] => array;
     }
     const test = isCaseSensitive === true ? String(value) : String(value).toLowerCase();
+    const testFn = e => {
+        const str = isCaseSensitive === true ? String(e) : String(e).toLowerCase();
+        return str.includes(test);
+    };
     return (array: T[]): T[] => array.filter(item => searchPointers.some(p => {
-        let v = p(item);
-        v = Array.isArray(v) ? v : [v];
-        return v.some(e => {
-            const str = isCaseSensitive === true ? String(e) : String(e).toLowerCase();
-            return str.includes(test);
-        })
+        const v = p(item);
+        if (Array.isArray(v)) {
+            return v.some(testFn);
+        }
+        return testFn(v);
     }));
 };

--- a/src/regex.ts
+++ b/src/regex.ts
@@ -14,5 +14,9 @@ export const regexp = <T>(input: RegexSearchInput): SearchFunction<T> => {
         return (array: T[]): T[] => array;
     }
     const regex = escape === true ? re`/${value}/${flags}` : new RegExp(value, flags);
-    return (array: T[]): T[] => array.filter(item => searchPointers.some(p => regex.test(String(p(item)))));
+    return (array: T[]): T[] => array.filter(item => searchPointers.some(p => {
+        let v = p(item);
+        v = Array.isArray(v) ? v : [v];
+        return v.some(e => regex.test(String(e)));
+    }));
 };

--- a/src/regex.ts
+++ b/src/regex.ts
@@ -14,9 +14,12 @@ export const regexp = <T>(input: RegexSearchInput): SearchFunction<T> => {
         return (array: T[]): T[] => array;
     }
     const regex = escape === true ? re`/${value}/${flags}` : new RegExp(value, flags);
+    const testFn = e => regex.test(String(e));
     return (array: T[]): T[] => array.filter(item => searchPointers.some(p => {
-        let v = p(item);
-        v = Array.isArray(v) ? v : [v];
-        return v.some(e => regex.test(String(e)));
+        const v = p(item);
+        if (Array.isArray(v)) {
+            return v.some(testFn);
+        }
+        return testFn(v);
     }));
 };

--- a/test/basic.js
+++ b/test/basic.js
@@ -27,6 +27,18 @@ test('basic text search on all values (nested object)', t => {
     ]);
 });
 
+test('basic text search on all arrays', t => {
+    const collection = [
+        {a: 'woo', b: ['foot', 'koot']},
+        {a: 'foo', b: ['w', 'x']},
+        {a: 'foo', b: ['b', 'c']},
+    ];
+    t.deepEqual(search({value: ',', scope: ['a', 'b']})(collection), []);
+    t.deepEqual(search({value: 'x', scope: ['a', 'b']})(collection), [
+        {a: 'foo', b: ['w', 'x']},
+    ]);
+});
+
 test('basic text search: do nothing when no scope is provided', t => {
     const collection = [
         {a: 'woo', b: 'foot'},

--- a/test/regex.js
+++ b/test/regex.js
@@ -27,6 +27,18 @@ test('regexp text search on all values (nested object)', t => {
     ]);
 });
 
+test('regexp text search on all arrays', t => {
+    const collection = [
+        {a: 'woo', b: ['foot', 'koot']},
+        {a: 'foo', b: ['w', 'x']},
+        {a: 'foo', b: ['b', 'c']},
+    ];
+    t.deepEqual(search({value: ',', scope: ['a', 'b']})(collection), []);
+    t.deepEqual(search({value: 'x', scope: ['a', 'b']})(collection), [
+        {a: 'foo', b: ['w', 'x']},
+    ]);
+});
+
 test('regexp text search: do nothing when no scope is provided', t => {
     const collection = [
         {a: 'woo', b: 'foot'},


### PR DESCRIPTION
I need to display multiple values in one table cell via an array but all contents in that table cell must be searchable via the search directive. `String(arr)` is a comma-delimited string so searching a single comma matches all table cells with multiple values.